### PR TITLE
fix(RS3): 周末统计错误由于日期是中文

### DIFF
--- a/MyYearWithGit/Data/ResultPackage/RS3.swift
+++ b/MyYearWithGit/Data/ResultPackage/RS3.swift
@@ -204,6 +204,6 @@ class ResultSection3: ResultSection {
             assertionFailure("Failed to extract weekday from date")
             return false
         }
-        return ["Saturday", "Sunday"].contains(calendar.weekdaySymbols[weekday - 1])
+        return ["Saturday", "Sunday", "星期六", "星期日"].contains(calendar.weekdaySymbols[weekday - 1])
     }
 }


### PR DESCRIPTION
<img width="812" alt="image" src="https://github.com/user-attachments/assets/881230b6-90fb-4aed-9704-3947c7fbb1bb" />

更新到 2024 版本后周末的统计变成了 0，定位到是日期返回的中文...